### PR TITLE
Feature mes 3781 add licence type logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-microservice-common",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-microservice-common",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "author": "DVSA",
   "license": "MIT",
   "description": "Code common to the MES microservice layer",

--- a/src/application/utils/__tests__/licence-type.spec.ts
+++ b/src/application/utils/__tests__/licence-type.spec.ts
@@ -1,6 +1,6 @@
 import { licenceToIssue } from '../licence-type';
 
-fdescribe('licenseToIssue', () => {
+describe('licenseToIssue', () => {
   describe('rule1', () => {
     it('should return Manual when category C, transmission automatic and code78 false', () => {
       const retValue = licenceToIssue('C', 'Automatic', false);

--- a/src/application/utils/__tests__/licence-type.spec.ts
+++ b/src/application/utils/__tests__/licence-type.spec.ts
@@ -1,0 +1,100 @@
+import { licenceToIssue } from '../licence-type';
+
+fdescribe('licenseToIssue', () => {
+  describe('rule1', () => {
+    it('should return Manual when category C, transmission automatic and code78 false', () => {
+      const retValue = licenceToIssue('C', 'Automatic', false);
+      expect(retValue).toBe('Manual');
+    });
+    it('should return Manual when category D, transmission automatic and code78 false', () => {
+      const retValue = licenceToIssue('D', 'Automatic', false);
+      expect(retValue).toBe('Manual');
+    });
+    it('should return Manual when category C+E, transmission automatic and code78 false', () => {
+      const retValue = licenceToIssue('C+E', 'Automatic', false);
+      expect(retValue).toBe('Manual');
+    });
+    it('should return Manual when category D+E, transmission automatic and code78 false', () => {
+      const retValue = licenceToIssue('D+E', 'Automatic', false);
+      expect(retValue).toBe('Manual');
+    });
+  });
+
+  describe('rule2', () => {
+    it('should return Manual when category C, transmission manual and code78 true', () => {
+      const retValue = licenceToIssue('C', 'Manual', true);
+      expect(retValue).toBe('Manual');
+    });
+    it('should return Manual when category D, transmission manual and code78 true', () => {
+      const retValue = licenceToIssue('D', 'Manual', true);
+      expect(retValue).toBe('Manual');
+    });
+    it('should return Manual when category C+E, transmission manual and code78 true', () => {
+      const retValue = licenceToIssue('C+E', 'Manual', true);
+      expect(retValue).toBe('Manual');
+    });
+    it('should return Manual when category D+E, transmission manual and code78 true', () => {
+      const retValue = licenceToIssue('D+E', 'Manual', true);
+      expect(retValue).toBe('Manual');
+    });
+  });
+  describe('rule3', () => {
+    it('should return Manual when category C, transmission manual and code78 false', () => {
+      const retValue = licenceToIssue('C', 'Manual', false);
+      expect(retValue).toBe('Manual');
+    });
+    it('should return Manual when category D, transmission manual and code78 false', () => {
+      const retValue = licenceToIssue('D', 'Manual', false);
+      expect(retValue).toBe('Manual');
+    });
+    it('should return Manual when category C+E, transmission manual and code78 false', () => {
+      const retValue = licenceToIssue('C+E', 'Manual', false);
+      expect(retValue).toBe('Manual');
+    });
+    it('should return Manual when category D+E, transmission manual and code78 false', () => {
+      const retValue = licenceToIssue('D+E', 'Manual', false);
+      expect(retValue).toBe('Manual');
+    });
+  });
+  describe('rule4', () => {
+    it('should return Automatic when category C, transmission Automatic and code78 true', () => {
+      const retValue = licenceToIssue('C', 'Automatic', true);
+      expect(retValue).toBe('Automatic');
+    });
+    it('should return Automatic when category D, transmission Automatic and code78 true', () => {
+      const retValue = licenceToIssue('D', 'Automatic', true);
+      expect(retValue).toBe('Automatic');
+    });
+    it('should return Automatic when category C+E, transmission Automatic and code78 true', () => {
+      const retValue = licenceToIssue('C+E', 'Automatic', true);
+      expect(retValue).toBe('Automatic');
+    });
+    it('should return Automatic when category D+E, transmission Automatic and code78 true', () => {
+      const retValue = licenceToIssue('D+E', 'Automatic', true);
+      expect(retValue).toBe('Automatic');
+    });
+  });
+  describe('other cases', () => {
+    it('should return the passed in vehicle transmission if code78 undefined', () => {
+      const retValue1 = licenceToIssue('C', 'Automatic', undefined);
+      const retValue2 = licenceToIssue('D', 'Manual', undefined);
+      expect(retValue1).toBe('Automatic');
+      expect(retValue2).toBe('Manual');
+    });
+
+    it('should return the passed in vehicle transmission for other categories and code78 true', () => {
+      const retValue1 = licenceToIssue('A', 'Automatic', true);
+      const retValue2 = licenceToIssue('B', 'Manual', true);
+      expect(retValue1).toBe('Automatic');
+      expect(retValue2).toBe('Manual');
+    });
+    it('should return the passed in vehicle transmission for other categories and code78 false', () => {
+      const retValue1 = licenceToIssue('A', 'Automatic', false);
+      const retValue2 = licenceToIssue('B', 'Manual', false);
+      expect(retValue1).toBe('Automatic');
+      expect(retValue2).toBe('Manual');
+    });
+
+  });
+
+});

--- a/src/application/utils/licence-type.ts
+++ b/src/application/utils/licence-type.ts
@@ -1,0 +1,21 @@
+const MANUAL: string = 'Manual';
+const AUTOMATIC: string = 'Automatic';
+
+export function licenceToIssue(
+    category: string,
+    vehicleTransmission: string,
+    code78Present?: boolean): string {
+
+  const categoriesToCheck: string[] = ['C', 'D', 'C+E', 'D+E'];
+
+  if (code78Present === undefined) {
+    return vehicleTransmission;
+  }
+
+  if (categoriesToCheck.findIndex(cat => cat === category) !== -1 &&
+  vehicleTransmission === AUTOMATIC && !code78Present) {
+    return MANUAL;
+  }
+
+  return vehicleTransmission;
+}


### PR DESCRIPTION
MES 3781 

Create a common routine to determine the license type to be issued based on category, transmission and code78 presence.  This will then be used in the RSIS mi export service to override the licence type when necessary.  (Realistically this will only occur for categories C,D,C+E and D+E where the vehicle transmission is Automatic and Code78 is not present on the licence.

## Pull Request checklist

- [X] [WIP] tag removed from PR title
- [X] PR has an understandable description

## Git feature branch checklist

- [X] branch name comply with our branching strategy
- [X] git branch contains relevant JIRA ticket number
- [X] branch rebased against the latest develop

## Sign off process checklist

- [X] Code has been tested manually
- [X] PR link added to JIRA